### PR TITLE
docker-compose & reduced minimum memory & fix for libsasl2-2

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,4 +76,8 @@ Each docker file contains a readme file, see below:
 * [Kafka](kafka/README.md)
 * [MySQL](mysql/README.md)
 
+To build Collector, Kafka & Mysql locally and run using docker-compose try:
 
+```
+docker-compose up
+```

--- a/collector/scripts/install
+++ b/collector/scripts/install
@@ -20,6 +20,9 @@ export DEBIAN_FRONTEND=noninteractive
 # Install base packages
 apt-get update
 
+# Install libsasl2-2 to fix "/usr/bin/openbmpd: error while loading shared libraries: libsasl2.so.2: cannot open shared object file: No such file or directory"
+apt-get install -y libsasl2-2
+
 # Fix ubuntu docker install
 sed -i 's/exit 101/exit 0/' /usr/sbin/policy-rc.d
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,38 @@
+version: '2'
+
+services:
+
+  openbmp_kafka:
+    build: ./kafka/
+    ports:
+     - "2181:2181"
+     - "9092:9092"
+    environment:
+     - KAFKA_FQDN=localhost
+
+  openbmp_mysql:
+    build: ./mysql/
+    ports:
+     - "3306:3306"
+     - "8001:8001"
+    volumes:
+     - /data/mysql
+     - /config
+    environment:
+     - REINIT_DB=1
+     - MEM=1
+     - KAFKA_FQDN=kafka
+    links:
+     - openbmp_kafka:kafka
+
+  openbmp_collector:
+    build: ./collector/
+    ports:
+     - "5000:5000"
+    volumes:
+     - /var/openbmp/config:/config
+    environment:
+     - OPENBMP_ADMIN_ID=collector1
+     - KAFKA_FQDN=kafka
+    links:
+     - openbmp_kafka:kafka

--- a/mysql/scripts/run
+++ b/mysql/scripts/run
@@ -30,8 +30,8 @@ if [[ ${SYS_TOTAL_MEM} -gt ${INIT_SYS_TOTAL_MEM} ]]; then
     echo "   Set the -e MEM=value in GB to less than or equal to system memory or do not set at all."
     exit 1
 
-elif [[ ${SYS_TOTAL_MEM} -lt 2000 ]]; then
-    echo "ERROR: At least 2GB of RAM is required.  Found ${SYS_TOTAL_MEM} MB. Cannot proceed."
+elif [[ ${SYS_TOTAL_MEM} -lt 1000 ]]; then
+    echo "ERROR: At least 1GB of RAM is required.  Found ${SYS_TOTAL_MEM} MB. Cannot proceed."
     exit 1
 fi
 


### PR DESCRIPTION
1) Added docker-compose file.
2) Reduced minimum memory in mysql container to allow MEM=1 and allow running in docker kitematik with 2GB VM memory.
3) Added libsasl2-2 installation command to fix "/usr/bin/openbmpd: error while loading shared libraries: libsasl2.so.2: cannot open shared object file: No such file or directory" while starting container.