### PR TITLE
Update DB_REST content.xml to configure mariadb

### DIFF
--- a/aio/scripts/install
+++ b/aio/scripts/install
@@ -57,7 +57,7 @@ rm -f /tmp/db_rest.war
 # configure DB_REST
 sed -r -i "s/username=\"[^\"]+\"/username=\"openbmp\"/" /var/lib/tomcat7/webapps/db_rest/META-INF/context.xml
 sed -r -i "s/password=\"[^\"]+\"/password=\"${OPENBMP_DB_PASSWORD}\"/" /var/lib/tomcat7/webapps/db_rest/META-INF/context.xml
-sed -r -i "s/jdbc:mysql:[^\"]+/jdbc:mysql:\/\/localhost:3306\/openBMP\//" /var/lib/tomcat7/webapps/db_rest/META-INF/context.xml
+sed -r -i "s/jdbc:mariadb:[^\"]+/jdbc:mariadb:\/\/localhost:3306\/openBMP\//" /var/lib/tomcat7/webapps/db_rest/META-INF/context.xml
 
 # --
 # -- MySQL/MariaDB server


### PR DESCRIPTION
Updates the tomcat7/webapps/db_rest/META_INF/context.xml to use local mariadb rather than the demo-int.openbmp.org. I guess at some point the database engine was changed from mysql to mariadb and the sed line no longer matches. Prior to this fix, accessing db_rest would give an HTTP 500, and catalina.out logfile would reference connection refused attempting connection to demo-int.openbmp.org:3306.