### PR TITLE
Resolve missing glibc dependency for snappy by using alpine with glibc

### DIFF
--- a/kafka/Dockerfile
+++ b/kafka/Dockerfile
@@ -10,7 +10,7 @@
 #
 
 # Pull base image.
-FROM alpine:3.3
+FROM frolvlad/alpine-glibc:alpine-3.7
 
 # Proxy/if behind firewall
 #   Update your /etc/sysconfig/docker or /etc/default/docker file by adding proxy envs there using export <var>=<val>


### PR DESCRIPTION
Fixes issue #10 "Kafka fails due to inability to load snappy library" for the standalone kafka container